### PR TITLE
Fix relative path for MacOS

### DIFF
--- a/src/servicenow_mcp/server.py
+++ b/src/servicenow_mcp/server.py
@@ -26,10 +26,12 @@ from servicenow_mcp.utils.tool_utils import get_tool_definitions
 
 # Set up logging
 #logging.basicConfig(level=logging.DEBUG)
+logFile = os.path.abspath(os.path.join(__file__ ,"../../..")) + '/.venv/app1.log'
 logger = logging.getLogger(__name__)
 session = None
 logging.basicConfig(
-    filename="C:/Development/servicenow-mcp/servicenow-mcp/app1.log",
+    # filename="C:/Development/servicenow-mcp/servicenow-mcp/app1.log",
+    filename=logFile,
     level=logging.DEBUG
 )
 logger.debug("Starting Log")


### PR DESCRIPTION
When the program executes on Mac, there is no `C` drive, so I attempted making this a relative directory

This code will set the logfile to `<Path>/servicenow-mcp/.venv/app1.log`

I have not tested this on windows, but hoping it works